### PR TITLE
Correct actionbar height

### DIFF
--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -37,7 +37,7 @@ Item {
       to solve this issue i've tried to get the actual height of the Status bar which is equal to 24dp
       and estimate the Density independence of it, after all this is done only in case if we are running within android os
     */
-    implicitHeight: Device.gridUnit * Qt.platform.os === "android" ? (Screen.height - Screen.desktopAvailableHeight)/24 : Units.dp
+    implicitHeight: Device.gridUnit * (Device.isMobile ? (Screen.height - Screen.desktopAvailableHeight)/24 : 1)
 
     anchors {
         left: parent.left

--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -1,15 +1,5 @@
-/*
- * QML Material - An application framework implementing Material Design.
- *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
- *               2015 Ricardo Vieira <ricardo.vieira@tecnico.ulisboa.pt>
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
-
 import QtQuick 2.4
+import QtQuick.Window 2.1
 import QtQuick.Layouts 1.1
 import Material 0.3
 import Material.ListItems 0.1 as ListItem
@@ -28,10 +18,15 @@ import Material.ListItems 0.1 as ListItem
    use the instance provided by the page. See the example in the \l Page documentation
    for more details.
  */
+
 Item {
     id: actionBar
-
-    implicitHeight: 1 * Device.gridUnit * Units.dp
+    /*
+      this resolves the issue where Units.dp and dp() function had no effect in android phone
+      to solve this issue i've tried to get the actual height of the Status bar which is equal to 24dp
+      and estimate the Density independence of it, after all this is done only in case if we are running within android os
+    */
+    implicitHeight: Device.gridUnit * Qt.platform.os === "android" ? (Screen.height - Screen.desktopAvailableHeight)/24 : Units.dp
 
     anchors {
         left: parent.left

--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -1,3 +1,14 @@
+/*
+ * QML Material - An application framework implementing Material Design.
+ *
+ * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *               2015 Ricardo Vieira <ricardo.vieira@tecnico.ulisboa.pt>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 import QtQuick 2.4
 import QtQuick.Window 2.1
 import QtQuick.Layouts 1.1


### PR DESCRIPTION
Raison : due to Units.dp issue, the actionbar layout in hight resolutions phones looks terrible, the problem is due to the ligne 73  fichier unit.cpp where the m_multiplier value is fixed to 1, this pull request comes to fixe temporary this issue
How : by determining the actual android screen dp from it's toolbar using this equation : 24*dp = Screen.height - Screen.desktopAvailableHeight
results : please see the screenshots
![img-20160612-wa0031](https://cloud.githubusercontent.com/assets/19345036/15991988/e4e3db90-30c1-11e6-9d3e-0c6ccc72383a.jpg)
![img-20160612-wa0032](https://cloud.githubusercontent.com/assets/19345036/15991989/e5137030-30c1-11e6-933a-699192be7522.jpg)
