### PR TITLE
fixing the Units.dp issue seen in the navigationDrower

### DIFF
--- a/src/window/NavigationDrawer.qml
+++ b/src/window/NavigationDrawer.qml
@@ -10,8 +10,8 @@
  */
 
 import QtQuick 2.4
+import QtQuick.Window 2.0
 import Material 0.3
-
 /*!
    \qmltype NavigationDrawer
    \inqmlmodule Material
@@ -24,8 +24,10 @@ PopupBase {
 
     overlayLayer: "dialogOverlayLayer"
     overlayColor: Qt.rgba(0, 0, 0, 0.3)
-
-    width: Math.min(parent.width - 1 * Device.gridUnit * Units.dp, 5 * Device.gridUnit * Units.dp)
+    /*!
+       \this fix a Units.dp issue seen in somes android phones (kitkat 4.4.4 as a case)
+     */
+    width: (Device.isMobile ? (Screen.height - Screen.desktopAvailableHeight)/24 : 1) * Device.gridUnit * Math.min(parent.width/Device.gridUnit - 1,5)
 
     anchors {
         left: mode === "left" ? parent.left : undefined


### PR DESCRIPTION
issue the same issue as the pull request number 3, please refer to it for more informations, this time with also the landscape and portrait mode
How : by determining the actual android screen dp from it's toolbar using this equation : 24*dp = Screen.height - Screen.desktopAvailableHeight
results : please see the screenshots
![img-20160612-wa0034](https://cloud.githubusercontent.com/assets/19345036/15992074/4f294f74-30c4-11e6-8049-8a632a1ead0c.jpg)
![img-20160612-wa0033](https://cloud.githubusercontent.com/assets/19345036/15992075/5525ba5c-30c4-11e6-8f03-be6c604abb19.jpg)
