### PR TITLE
update the Qt verions to 5.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 install:
   - sudo add-apt-repository -y ppa:beineri/opt-qt551-trusty
-  - sudo add-apt-repository -y ppa:beineri/opt-qt56-trusty
+  - sudo add-apt-repository -y ppa:beineri/opt-qt561-trusty
   - sudo apt-get update
   - sudo apt-get -y install pep8 pyflakes python python-pip npm nodejs nodejs-legacy
   - sudo apt-get -y install qt55declarative qt55quickcontrols qt55graphicaleffects qt55tools qt55svg


### PR DESCRIPTION
travis check failled, reason : 
The command "sudo add-apt-repository -y ppa:beineri/opt-qt56-trusty" failed and exited with 1 during .
Fix : 
replacing it with the latest version [ppa:beineri/opt-qt561-trusty](https://launchpad.net/~beineri/+archive/ubuntu/opt-qt561-trusty)
